### PR TITLE
Add AMI/ASRockRack adapter support

### DIFF
--- a/lib/radfish.rb
+++ b/lib/radfish.rb
@@ -98,13 +98,19 @@ require_relative 'radfish/client'
 
 # Auto-load adapters if available
 begin
-  require 'radfish/idrac_adapter'
+  require 'radfish-idrac'
 rescue LoadError
   # radfish-idrac gem not installed
 end
 
 begin
-  require 'radfish/supermicro_adapter'
+  require 'radfish-supermicro'
 rescue LoadError
   # radfish-supermicro gem not installed
+end
+
+begin
+  require 'radfish-ami'
+rescue LoadError
+  # radfish-ami gem not installed
 end

--- a/lib/radfish/cli.rb
+++ b/lib/radfish/cli.rb
@@ -340,7 +340,15 @@ module Radfish
         case subcommand
         when 'summary', 'all'
           data = client.storage_summary
-          output_result(data, nil) if options[:json]
+          if options[:json]
+            puts JSON.pretty_generate(data)
+          else
+            puts "=== Storage Summary ===".green
+            puts "Total Controllers: #{data[:controller_count]}".cyan
+            data[:controllers]&.each do |ctrl|
+              puts "  #{ctrl[:name] || ctrl[:id]}: #{ctrl[:drive_count]} drives, #{ctrl[:volume_count]} volumes".cyan
+            end
+          end
         when 'controllers'
           ctrls = client.controllers
           if options[:json]

--- a/lib/radfish/vendor_detector.rb
+++ b/lib/radfish/vendor_detector.rb
@@ -124,7 +124,9 @@ module Radfish
         when /lenovo/i, /thinkserver/i, /thinksystem/i
           return 'lenovo'
         when /asrockrack/i, /asrock/i
-          return 'asrockrack'
+          return 'ami'
+        when /ami/i, /megarac/i
+          return 'ami'
         end
       end
       
@@ -167,7 +169,8 @@ module Radfish
               return 'hpe' if model.match?(/ilo/i) || description.match?(/ilo/i)
               return 'supermicro' if model.match?(/supermicro/i) || description.match?(/smc/i)
               return 'lenovo' if model.match?(/lenovo/i) || description.match?(/xcc/i)
-              return 'asrockrack' if model.match?(/asrock/i)
+              return 'ami' if model.match?(/asrock/i) || description.match?(/asrock/i)
+              return 'ami' if description.match?(/bmc/i) && manager_data.dig('Oem', 'Ami')
             end
           end
         end
@@ -199,7 +202,9 @@ module Radfish
       when /lenovo/i
         'lenovo'
       when /asrock/i
-        'asrockrack'
+        'ami'
+      when /ami/i, /megarac/i
+        'ami'
       else
         vendor_string.to_s.downcase
       end

--- a/lib/radfish/version.rb
+++ b/lib/radfish/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Radfish
-  VERSION = "0.2.9"
+  VERSION = "0.2.10"
 end


### PR DESCRIPTION
- Add auto-loading for radfish-ami gem
- Update vendor detector to recognize AMI BMC (MegaRAC) and ASRockRack
- Fix adapter require paths to use gem names (radfish-idrac, radfish-supermicro)
- Add text output for storage summary CLI command
- Bump version to 0.2.10