### PR TITLE
Use `persistence` everywhere for `set_boot_override()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ client.mount_iso_and_boot("http://example.com/os.iso")
 options = client.boot_options
 
 # Set one-time boot
-client.set_boot_override("Pxe", persistent: false)
+client.set_boot_override("Pxe", persistence: 'Once')
 
 # Quick boot methods
 client.boot_to_pxe

--- a/lib/radfish/core/boot.rb
+++ b/lib/radfish/core/boot.rb
@@ -7,7 +7,7 @@ module Radfish
         raise NotImplementedError, "Adapter must implement #boot_config"
       end
       
-      def set_boot_override(target, persistent: false)
+      def set_boot_override(target, persistence: nil, mode: nil)
         raise NotImplementedError, "Adapter must implement #set_boot_override"
       end
       

--- a/spec/support/mock_adapter.rb
+++ b/spec/support/mock_adapter.rb
@@ -142,23 +142,23 @@ module Radfish
       []
     end
     
-    def set_boot_override(target, persistence: nil, mode: nil, persistent: false)
+    def set_boot_override(target, persistence: nil, mode: nil)
       true
     end
     
-    def boot_to_cd(mode: nil, persistence: nil)
+    def boot_to_cd(persistence: nil, mode: nil)
       set_boot_override('Cd', persistence: persistence, mode: mode)
     end
     
-    def boot_to_pxe(mode: nil, persistence: nil)
+    def boot_to_pxe(persistence: nil, mode: nil)
       set_boot_override('Pxe', persistence: persistence, mode: mode)
     end
     
-    def boot_to_disk(mode: nil, persistence: nil)
+    def boot_to_disk(persistence: nil, mode: nil)
       set_boot_override('Hdd', persistence: persistence, mode: mode)
     end
     
-    def boot_to_usb(mode: nil, persistence: nil)
+    def boot_to_usb(persistence: nil, mode: nil)
       set_boot_override('Usb', persistence: persistence, mode: mode)
     end
     


### PR DESCRIPTION
Currently there's some places that uses `persistence`, `persistent` and `enabled` for same purpose.
This is very confusing and also because of it currently `set_boot_override()` is broken for `redfish-ami`.
So just use `persistence` everywhere.
